### PR TITLE
Make it compile with latest SDK

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,5 +21,5 @@ pico_generate_pio_header(rmiieth ${CMAKE_CURRENT_LIST_DIR}/rmii_ext_clk.pio)
 
 target_include_directories(rmiieth PRIVATE ${CMAKE_CURRENT_LIST_DIR})
 
-target_link_libraries(rmiieth PRIVATE pico_stdlib hardware_pio hardware_dma lwip)
+target_link_libraries(rmiieth PRIVATE pico_stdlib hardware_pio hardware_dma pico_lwip pico_lwip_nosys pico_lwip_http)
 pico_add_extra_outputs(rmiieth)

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ The RMII module requires 9 pins to be connected to the Pico:
 * Clock
 
     50MHz refclk from the RMII module.
+    Could be any of gpio 20, 22, 12 or 14.
 
 * TX Pins
 
@@ -65,7 +66,7 @@ The RMII module requires 9 pins to be connected to the Pico:
         * TX1
         * TX_EN     (pin_tx_valid)
 
-    The TX0 and TX1 pins must be adjacent.
+    The TX0 and TX1 pins must be adjacent and in order (PIN_TX1 = PIN_TX0 + 1).
 
 * RX Pins
 
@@ -73,7 +74,7 @@ The RMII module requires 9 pins to be connected to the Pico:
         * RX1
         * CRS       (pin_rx_valid)
 
-    The RX0 and RX1 pins must be adjacent.
+    The RX0 and RX1 pins must be adjacent and in order (PIN_RX1 = PIN_RX0 + 1).
     
 ### Software configuration
 

--- a/main.c
+++ b/main.c
@@ -7,6 +7,10 @@
 #include "pkt_utils.h"
 #include "hardware/pio.h"
 #include "hardware/dma.h"
+#include "hardware/pll.h"
+#include "hardware/clocks.h"
+#include "hardware/structs/pll.h"
+#include "hardware/structs/clocks.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include "lwip/opt.h"

--- a/pkt_queue.c
+++ b/pkt_queue.c
@@ -6,7 +6,7 @@
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include "pico/platform.h"
+#include "pico.h"
 
 void pkt_queue_init( pkt_queue* pq, uint8_t* data, int32_t size )
 {

--- a/rmii_ext_clk.pio
+++ b/rmii_ext_clk.pio
@@ -12,7 +12,7 @@
 ;
 ;----------------------------------------------------------------------------------------------------
 
-.program clk
+.program eth_clk
 .wrap_target
         wait    0 pin 0
         irq     4
@@ -29,7 +29,7 @@
 ;
 ;----------------------------------------------------------------------------------------------------
 
-.program rx
+.program eth_rx
 
         ; when this finishes, we'll flush 32 more bits of data
         ; to hopefully ensure we got everything...
@@ -64,7 +64,7 @@ halt:   jmp     halt
 ;
 ;----------------------------------------------------------------------------------------------------
 
-.program tx
+.program eth_tx
 .side_set 1 opt
 .wrap_target
         nop     side 0                          ; ensure TX_EN is low

--- a/rmiieth.c
+++ b/rmiieth.c
@@ -151,8 +151,8 @@ void rmiieth_init( rmiieth_config* cfg )
     // initialize the clk program
     //
 
-    cfg->clk_offset = pio_add_program( cfg->pio, &clk_program );
-    cfg->clk_config = clk_program_get_default_config( cfg->clk_offset );
+    cfg->clk_offset = pio_add_program( cfg->pio, &eth_clk_program );
+    cfg->clk_config = eth_clk_program_get_default_config( cfg->clk_offset );
     sm_config_set_in_pins( &cfg->clk_config, cfg->pin_clk );
     pio_sm_set_consecutive_pindirs( cfg->pio, cfg->clk_sm, cfg->pin_clk, 1, false );
     pio_sm_init( cfg->pio, cfg->clk_sm, cfg->clk_offset, &cfg->clk_config );
@@ -162,8 +162,8 @@ void rmiieth_init( rmiieth_config* cfg )
     // init the RX program
     //
 
-    cfg->rx_offset = pio_add_program( cfg->pio, &rx_program );
-    cfg->rx_config = rx_program_get_default_config( cfg->rx_offset );
+    cfg->rx_offset = pio_add_program( cfg->pio, &eth_rx_program );
+    cfg->rx_config = eth_rx_program_get_default_config( cfg->rx_offset );
     sm_config_set_in_pins( &cfg->rx_config, cfg->pin_rx_base );
     sm_config_set_in_shift( &cfg->rx_config, true, true, 32 );
     sm_config_set_jmp_pin( &cfg->rx_config, cfg->pin_rx_valid );
@@ -193,8 +193,8 @@ void rmiieth_init( rmiieth_config* cfg )
     // init the TX program
     //
 
-    cfg->tx_offset = pio_add_program( cfg->pio, &tx_program );
-    cfg->tx_config = tx_program_get_default_config( cfg->tx_offset );
+    cfg->tx_offset = pio_add_program( cfg->pio, &eth_tx_program );
+    cfg->tx_config = eth_tx_program_get_default_config( cfg->tx_offset );
     sm_config_set_out_pins( &cfg->tx_config, cfg->pin_tx_base, 2 );
     sm_config_set_out_shift( &cfg->tx_config, true, true, 32 );
     sm_config_set_set_pins( &cfg->tx_config, cfg->pin_tx_base, 2 );


### PR DESCRIPTION
I had some compilation issue with the repo as-is, so updated a few things to make it work with the current version of the SDK.
Not sure why I was getting errors with the PIO program names, just prefixed them and it's now all good also.